### PR TITLE
Use 'atv.available' to avoid connecting twice

### DIFF
--- a/homeassistant/components/media_player/androidtv.py
+++ b/homeassistant/components/media_player/androidtv.py
@@ -172,7 +172,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     if CONF_ADB_SERVER_IP not in config:
         atv = AndroidTV(host)
-        if atv.connect() is False:
+        if not atv.available:
             # "python-adb" with adbkey
             if CONF_ADBKEY in config:
                 adbkey = config[CONF_ADBKEY]


### PR DESCRIPTION
Since the "python-adb" package is fragile, we should use the `available` property to check whether the connection was successfully established rather than trying to connect again. If the connection attempt in the `androidtv` package failed due to a socket error, it will set `self._adb = None` and thus `self.available` (i.e., `bool(self._adb)`) will be false. 