### PR TITLE
Bump androidtv to 0.0.7

### DIFF
--- a/homeassistant/components/media_player/androidtv.py
+++ b/homeassistant/components/media_player/androidtv.py
@@ -27,7 +27,6 @@ https://home-assistant.io/components/media_player.androidtv/
 import logging
 import functools
 import os
-import threading
 import voluptuous as vol
 
 from homeassistant.components.media_player import (

--- a/homeassistant/components/media_player/androidtv.py
+++ b/homeassistant/components/media_player/androidtv.py
@@ -31,11 +31,11 @@ import threading
 import voluptuous as vol
 
 from homeassistant.components.media_player import (
-    DOMAIN, MediaPlayerDevice, PLATFORM_SCHEMA, SUPPORT_NEXT_TRACK,
-    SUPPORT_PAUSE, SUPPORT_PLAY,
+    MediaPlayerDevice, PLATFORM_SCHEMA)
+from homeassistant.components.media_player.const import (
+    DOMAIN, SUPPORT_NEXT_TRACK, SUPPORT_PAUSE, SUPPORT_PLAY,
     SUPPORT_PREVIOUS_TRACK, SUPPORT_STOP, SUPPORT_TURN_OFF,
     SUPPORT_TURN_ON, SUPPORT_VOLUME_MUTE, SUPPORT_VOLUME_STEP)
-
 from homeassistant.const import (
     ATTR_ENTITY_ID, CONF_HOST, CONF_NAME, CONF_PORT,
     STATE_IDLE, STATE_PAUSED, STATE_PLAYING, STATE_OFF)

--- a/homeassistant/components/media_player/androidtv.py
+++ b/homeassistant/components/media_player/androidtv.py
@@ -291,9 +291,6 @@ class AndroidTVDevice(MediaPlayerDevice):
         self._unique_id = 'androitv-{}-{}'.format(
             name, self._properties['serialno'])
 
-        # whether or not the ADB connection is currently in use
-        self.adb_lock = threading.Lock()
-
         # ADB exceptions to catch
         if not self.androidtv.adb_server_ip:
             # "python-adb"

--- a/homeassistant/components/media_player/androidtv.py
+++ b/homeassistant/components/media_player/androidtv.py
@@ -43,7 +43,7 @@ from homeassistant.exceptions import PlatformNotReady
 from homeassistant.helpers import device_registry as dr
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['androidtv==0.0.4']
+REQUIREMENTS = ['androidtv==0.0.6']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -250,55 +250,27 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
 
 def adb_decorator(override_available=False):
-    """Send an ADB command if the device is available and not locked."""
-    def adb_wrapper(func):
+    """Send an ADB command if the device is available and catch exceptions."""
+    def _adb_decorator(func):
         """Wait if previous ADB commands haven't finished."""
         @functools.wraps(func)
-        def _adb_wrapper(self, *args, **kwargs):
+        def __adb_decorator(self, *args, **kwargs):
             # If the device is unavailable, don't do anything
             if not self.available and not override_available:
                 return None
 
-            # "python-adb"
-            if not self.androidtv.adb_server_ip:
-                # If an ADB command is already running, skip this command
-                if not self.adb_lock.acquire(blocking=False):
-                    _LOGGER.info('Skipping an ADB command because a previous '
-                                 'command is still running')
-                    return None
+            try:
+                return func(self, *args, **kwargs)
+            except self.exceptions as err:
+                _LOGGER.error(
+                    "Failed to execute an ADB command. ADB connection re-"
+                    "establishing attempt in the next update. Error: %s", err)
+                self._available = False  # pylint: disable=protected-access
+                return None
 
-                # More ADB commands will be prevented while trying this one
-                try:
-                    returns = func(self, *args, **kwargs)
-                except self.exceptions:
-                    _LOGGER.error('Failed to execute an ADB command;'
-                                  ' will attempt to re-establish the ADB'
-                                  ' connection in the next update')
-                    returns = None
-                    _LOGGER.warning(
-                        "Device %s became unavailable.", self._name)
-                    self._available = False  # pylint: disable=protected-access
-                finally:
-                    self.adb_lock.release()
+        return __adb_decorator
 
-            # "pure-python-adb"
-            else:
-                try:
-                    returns = func(self, *args, **kwargs)
-                except self.exceptions:
-                    _LOGGER.error('Failed to execute an ADB command;'
-                                  ' will attempt to re-establish the ADB'
-                                  ' connection in the next update')
-                    returns = None
-                    _LOGGER.warning(
-                        "Device %s became unavailable.", self._name)
-                    self._available = False  # pylint: disable=protected-access
-
-            return returns
-
-        return _adb_wrapper
-
-    return adb_wrapper
+    return _adb_decorator
 
 
 class AndroidTVDevice(MediaPlayerDevice):

--- a/homeassistant/components/media_player/androidtv.py
+++ b/homeassistant/components/media_player/androidtv.py
@@ -43,7 +43,7 @@ from homeassistant.exceptions import PlatformNotReady
 from homeassistant.helpers import device_registry as dr
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['androidtv==0.0.6']
+REQUIREMENTS = ['androidtv==0.0.7']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -136,7 +136,7 @@ alpha_vantage==2.1.0
 amcrest==1.2.3
 
 # homeassistant.components.media_player.androidtv
-androidtv==0.0.4
+androidtv==0.0.6
 
 # homeassistant.components.switch.anel_pwrctrl
 anel_pwrctrl-homeassistant==0.0.1.dev2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -136,7 +136,7 @@ alpha_vantage==2.1.0
 amcrest==1.2.3
 
 # homeassistant.components.media_player.androidtv
-androidtv==0.0.6
+androidtv==0.0.7
 
 # homeassistant.components.switch.anel_pwrctrl
 anel_pwrctrl-homeassistant==0.0.1.dev2


### PR DESCRIPTION
## Description:

This moves the ADB lock into the `androidtv` package and out of the `adb_decorator`.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
